### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "mediawiki/whats-nearby",
 	"type": "mediawiki-extension",
-	"description": "Provide geolocation information to templates",
+	"description": "Provides geolocation information to templates",
 	"keywords": [
 		"MediaWiki",
 		"Geolocation",
@@ -20,7 +20,7 @@
 	"require": {
 		"php": ">=5.3.0",
 		"composer/installers": "1.*,>=1.0.1",
-		"mediawiki/maps": "~3.5|~4.0",
+		"mediawiki/maps": "~3.5|~4.0|~5.0",
 		"onoi/shared-resources": "~0.1"
 	},
 	"extra": {


### PR DESCRIPTION
Refs: #10 - sort of and recurring.

This time bad, bad, @JeroenDeDauw ;) bumped to 5.0.0-alpha and now sandbox complains about missing matching packages. :) This commit assumes that there is no breaking change for the What's Nearby extension.